### PR TITLE
KOGITO-9706: more robustness in post-release job

### DIFF
--- a/.ci/jenkins/Jenkinsfile.kie-kogito-post-release
+++ b/.ci/jenkins/Jenkinsfile.kie-kogito-post-release
@@ -95,6 +95,10 @@ pipeline {
             steps {
                 script {
                     dir("${docsRepo}/doc-content/kogito-docs") {
+                        if (githubscm.isTagExist('origin', "${getKogitoDocsVersion()}-kogito")) {
+                            githubscm.removeRemoteTag('origin', "${getKogitoDocsVersion()}-kogito", getGitAuthorCredsId())
+                        }
+                        githubscm.removeLocalTag("${getKogitoDocsVersion()}-kogito"))
                         githubscm.tagRepository("${getKogitoDocsVersion()}-kogito")
                     }
                 }
@@ -124,6 +128,9 @@ pipeline {
             }
         }
         stage('Upload kie-kogito-docs to filemgmt') {
+            when {
+                expression {!isSkipUpload()}
+            }
             steps {
                 sshagent(credentials: ['KogitoDocsUpload']) {
                     script {
@@ -134,15 +141,25 @@ pipeline {
                 }
             }
         }
-        stage('Bump up kie-kogito-docs to next SNAPSHOT'){
+        stage('Bump up kogito-docs to next SNAPSHOT'){
             steps{
                 dir("${docsRepo}/doc-content/kogito-docs") {
                     script{
                         maven.mvnVersionsSet(util.getNextVersion(getKogitoDocsVersion(), 'minor'))
-                        if ( isNewVersionRequired() ) {
-                            // bump up if the current kie-version on main branch is greater then the kie-version on main-kogito branch
-                            maven.mvnVersionsUpdateParentAndChildModules("${getKieVersion()}", true)
-                        }
+                        sh 'head -n30 pom.xml'
+                    }
+                }
+            }
+        }
+        stage('Bump up kie-version if required') {
+            when {
+                expression {isNewVersionRequired()}
+            }
+            steps {
+                script {
+                    dir("${docsRepo}") {
+                        // bump up if the current kie-version on main branch is greater then the kie-version on main-kogito branch
+                        maven.mvnVersionsUpdateParentAndChildModules("${getKieVersion()}", true)
                         sh 'head -n30 pom.xml'
                     }
                 }
@@ -218,6 +235,10 @@ void sendNotification(String body) {
 
 boolean isNewVersionRequired() {
     return params.BUMP_UP
+}
+
+boolean isSkipUpload() {
+    return params.SKIP_UPLOAD
 }
 
 String getGitAuthorCredsId() {

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -29,8 +29,9 @@ void setupKogitoDocsJob() {
             stringParam('KOGITO_RELEASE_NUMBER', '12409824', 'Jira release notes number of kogito release')
             stringParam('TOOLING_RELEASE_NUMBER', '12409093', 'Jira release notes number of kogito-tooling')
             stringParam('KOGITO_TOOLING_VERSION', '0.30.0', 'Kogito-tooling version to use as Major.minor.micro')
-            booleanParam('BUMP_UP' , false, 'Is a new KIE version needed?')
+            booleanParam('BUMP_UP' , false, 'Please check only if a new KIE version needed')
             stringParam('KIE_VERSION' , '', 'KIE version to bump up to as Major.minor.micro-SNAPSHOT')
+            booleanParam('SKIP_UPLOAD' , false, 'Please check only if the step for uploading the docs to filemgmt should be skipped')
         }
     }
 }


### PR DESCRIPTION
**Thank you for submitting this pull request**

**JIRA**: [KOGITO-9706](https://issues.redhat.com/browse/KOGITO-9706)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* paste the link(s) from GitHub here
* link 2
* link 3 etc.

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
