### PR TITLE
kie-issues#776: automate PR merge into protected branches

### DIFF
--- a/.ci/jenkins/Jenkinsfile.kie-kogito-post-release
+++ b/.ci/jenkins/Jenkinsfile.kie-kogito-post-release
@@ -153,9 +153,7 @@ pipeline {
                     script{
                         // Add changed files, commit, open and merge PR
                         String prLink = commitAndCreatePR(commitMsg, PR_BRANCH, getDocsRepoBranch())
-                        sh "git checkout ${getDocsRepoBranch()}"
-                        mergeAndPush(prLink, getDocsRepoBranch())
-                        githubscm.removeRemoteBranch('origin', PR_BRANCH, getGitAuthorPushCredsId())
+                        approveAndMergePR(prLink)
                     }
                 }
             }
@@ -241,10 +239,10 @@ String parseCommunityVersion(String docVersion) {
     return "${versionSplit[0]}.${versionSplit[1]}"
 }
 
-void mergeAndPush(String prLink, String targetBranch) {
+void approveAndMergePR(String prLink) {
     if (prLink?.trim()) {
+        githubscm.approvePR(prLink, getGitAuthorPushCredsId())
         githubscm.mergePR(prLink, getGitAuthorPushCredsId())
-        githubscm.pushObject('origin', targetBranch, getGitAuthorPushCredsId())
     }
 }
 
@@ -253,5 +251,5 @@ String commitAndCreatePR(String commitMsg, String localBranch, String targetBran
     githubscm.setUserConfigFromCreds(getGitAuthorPushCredsId())
     githubscm.commitChanges(commitMsg)
     githubscm.pushObject('origin', localBranch, getGitAuthorPushCredsId())
-    return githubscm.createPR(commitMsg, prBody, targetBranch, getGitAuthorPushCredsId())
+    return githubscm.createPR(commitMsg, prBody, targetBranch, getGitAuthorCredsId())
 }


### PR DESCRIPTION
Part of:
* apache/incubator-kie-issues#776

Other related PRs:
* apache/incubator-kie-kogito-pipelines#1194
* apache/incubator-kie-benchmarks#286
* apache/incubator-kie-docs#4536
* apache/incubator-kie-kogito-runtimes#3501
* apache/incubator-kie-kogito-apps#2047
* apache/incubator-kie-kogito-examples#1914
* apache/incubator-kie-kogito-docs#626
* apache/incubator-kie-drools#5927
* apache/incubator-kie-optaplanner#3083
* apache/incubator-kie-kogito-serverless-operator#462

Replacing old approach to merge PRs:  merge locally + push into remote

New behavior relies on gh cli directly to approve and merge PR.