### PR TITLE
Replace old links to kie.apache.org

### DIFF
--- a/drools-docs/README.adoc
+++ b/drools-docs/README.adoc
@@ -19,7 +19,7 @@ with the License.  You may obtain a copy of the License at
 
 = Drools documentation website
 
-https://www.drools.org/docs[www.drools.org/docs]
+https://kie.apache.org/docs/documentation/[https://kie.apache.org/docs/documentation/]
 
 == How it works
 

--- a/drools-docs/pom.xml
+++ b/drools-docs/pom.xml
@@ -34,7 +34,7 @@
   <packaging>pom</packaging>
 
   <name>Drools documentation</name>
-  <url>https://www.drools.org/</url>
+  <url>https://kie.apache.org/docs/documentation/</url>
 
   <properties>
     <antora.playbook>antora-playbook.yml</antora.playbook>

--- a/drools-docs/src/modules/ROOT/pages/DMN/_dmn-con.adoc
+++ b/drools-docs/src/modules/ROOT/pages/DMN/_dmn-con.adoc
@@ -22,4 +22,4 @@ with the License.  You may obtain a copy of the License at
 
 Decision Model and Notation (DMN) is a standard established by the Object Management Group (OMG) for describing and modeling operational decisions. DMN defines an XML schema that enables DMN models to be shared between DMN-compliant platforms and across organizations so that business analysts and business rules developers can collaborate in designing and implementing DMN decision services. The DMN standard is similar to and can be used together with the Business Process Model and Notation (BPMN) standard for designing and modeling business processes.
 
-For general information about the background and applications of DMN, see the https://www.drools.org/learn/dmn.html[Drools DMN landing page].
+For general information about the background and applications of DMN, see the https://kie.apache.org/docs/components/drools/drools_dmn[Drools DMN landing page].

--- a/drools-docs/src/modules/ROOT/pages/DMN/_dmn-execution-kogito-proc.adoc
+++ b/drools-docs/src/modules/ROOT/pages/DMN/_dmn-execution-kogito-proc.adoc
@@ -24,4 +24,4 @@ Interacting with the REST endpoints of {KOGITO} cloud-native microservice includ
 
 For a quick getting started guide for {KOGITO} on Quarkus, see the Quarkus guide for https://quarkus.io/guides/kogito-dmn[using {KOGITO} DMN support to add Decision Automation capabilities to a Quarkus application].
 
-For more information about {KOGITO} or migrating to {KOGITO} microservices, see the https://kogito.kie.org/guides/[Kogito website for documentation].
+For more information about {KOGITO} or migrating to {KOGITO} microservices, see the https://kie.apache.org/docs/components/kogito/[Kogito website for documentation].

--- a/drools-docs/src/modules/ROOT/pages/DMN/_dmn-support-con.adoc
+++ b/drools-docs/src/modules/ROOT/pages/DMN/_dmn-support-con.adoc
@@ -70,4 +70,4 @@ In addition to all DMN conformance level 3 requirements, {DMN_ENGINE} also inclu
 For more information about including external DMN files with your {PRODUCT} project packaging and deployment method, see
 the xref:KIE/index.adoc[Build, Deploy, Utilize and Run section].
 
-You can design a new DMN decision service using a {KOGITO} microservice as an alternative for the cloud-native capabilities of DMN decision services. You could also migrate your existing DMN service to a {KOGITO} microservice. For more information about {KOGITO} or migrating to {KOGITO} microservices, see the https://kogito.kie.org/guides/[Kogito website for documentation].
+You can design a new DMN decision service using a {KOGITO} microservice as an alternative for the cloud-native capabilities of DMN decision services. You could also migrate your existing DMN service to a {KOGITO} microservice. For more information about {KOGITO} or migrating to {KOGITO} microservices, see the https://kie.apache.org/docs/components/kogito/[Kogito website for documentation].

--- a/drools-docs/src/modules/ROOT/pages/getting-started/_getting-started-decision-services.adoc
+++ b/drools-docs/src/modules/ROOT/pages/getting-started/_getting-started-decision-services.adoc
@@ -42,7 +42,7 @@ include::../DMN/_dmn-gs-new-project-creating-proc.adoc[leveloffset=+1]
 == Decision Model and Notation (DMN)
 Decision Model and Notation (DMN) is a standard established by the Object Management Group (OMG) for describing and modeling operational decisions. DMN defines an XML schema that enables DMN models to be shared between DMN-compliant platforms and across organizations so that business analysts and business rules developers can collaborate in designing and implementing DMN decision services. The DMN standard is similar to and can be used together with the Business Process Model and Notation (BPMN) standard for designing and modeling business processes.
 
-For general information about the background and applications of DMN, see the https://www.drools.org/learn/dmn.html[Drools DMN landing page].
+For general information about the background and applications of DMN, see the https://kie.apache.org/docs/components/drools/drools_dmn[Drools DMN landing page].
 
 include::../DMN/_dmn-gs-creating-drd-proc.adoc[leveloffset=+2]
 include::../DMN/_dmn-gs-creating-custom-datatypes-proc.adoc[leveloffset=+2]

--- a/drools-docs/src/modules/ROOT/pages/introduction/index.adoc
+++ b/drools-docs/src/modules/ROOT/pages/introduction/index.adoc
@@ -27,13 +27,13 @@ include::../_artifacts/document-attributes.adoc[]
 [id='{context}']
 = Introduction
 
-link:https://www.drools.org/[{PRODUCT}] is a set of projects focusing on intelligent automation and decision management, most notably providing a forward-chaining and backward-chaining inference-based **rule engine**, DMN decisions engine and other projects. A rule engine is a fundamental building block to create an expert system which, in artificial intelligence, is a computer system that emulates the decision-making ability of a human expert.
+link:https://kie.apache.org/docs/components/drools/[{PRODUCT}] is a set of projects focusing on intelligent automation and decision management, most notably providing a forward-chaining and backward-chaining inference-based **rule engine**, DMN decisions engine and other projects. A rule engine is a fundamental building block to create an expert system which, in artificial intelligence, is a computer system that emulates the decision-making ability of a human expert.
 
 {PRODUCT} is part of KIE (Knowledge Is Everything) open source community, which consists of various related projects, or groups of projects, that complete a portfolio of solutions for business automation and management. The most important other KIE projects or groups of projects are:
 
-1. link:https://kogito.kie.org/[Kogito] is a cloud-native business automation for building intelligent applications, backed by battle-tested capabilities. It consists of multiple components, including {PRODUCT}, UI modelling tools, like VS Code editors extensions, etc.
-2. link:https://www.optaplanner.org/[OptaPlanner] is a fast, easy-to-use, open source AI constraint solver for software developers. It is a lightweight, embeddable planning engine.
-3. link:https://www.jbpm.org/[jBPM] is a toolkit for building business applications to help automate business processes and decisions.
+1. link:https://kie.apache.org/docs/components/kogito/[Kogito] is a cloud-native business automation for building intelligent applications, backed by battle-tested capabilities. It consists of multiple components, including {PRODUCT}, UI modelling tools, like VS Code editors extensions, etc.
+2. link:https://kie.apache.org/docs/components/optaplanner/[OptaPlanner] is a fast, easy-to-use, open source AI constraint solver for software developers. It is a lightweight, embeddable planning engine.
+3. link:https://kie.apache.org/docs/components/jbpm/[jBPM] is a toolkit for building business applications to help automate business processes and decisions.
 
 == Additional resources
 link:https://github.com/apache/incubator-kie-drools/[{PRODUCT} source code]

--- a/drools-docs/src/modules/ROOT/pages/language-reference/_drl-rules.adoc
+++ b/drools-docs/src/modules/ROOT/pages/language-reference/_drl-rules.adoc
@@ -21,7 +21,7 @@ with the License.  You may obtain a copy of the License at
 = Drools Rule Language (DRL)
 
 [role="_abstract"]
-Drools Rule Language (DRL) is a notation established by the https://www.drools.org/[Drools] open source business automation project for defining and describing business rules. You define DRL rules in `.drl` text files. A DRL file can contain one or more rules that define at a minimum the rule conditions (`when`) and actions (`then`).
+Drools Rule Language (DRL) is a notation established by the https://kie.apache.org/docs/components/drools/[Drools] open source business automation project for defining and describing business rules. You define DRL rules in `.drl` text files. A DRL file can contain one or more rules that define at a minimum the rule conditions (`when`) and actions (`then`).
 
 DRL files consist of the following components:
 

--- a/drools-docs/src/modules/ROOT/pages/migration-guide/_missing_features_components.adoc
+++ b/drools-docs/src/modules/ROOT/pages/migration-guide/_missing_features_components.adoc
@@ -22,7 +22,7 @@ with the License.  You may obtain a copy of the License at
 [id='kie-server_{context}']
 == {KIE_SERVER}
 
-{KIE_SERVER} is retired and no longer a component since {PRODUCT} 8. If your system is working on {KIE_SERVER} with {PRODUCT} 7, consider migration to https://kogito.kie.org/[{KOGITO}].
+{KIE_SERVER} is retired and no longer a component since {PRODUCT} 8. If your system is working on {KIE_SERVER} with {PRODUCT} 7, consider migration to https://kie.apache.org/docs/components/kogito/[{KOGITO}].
 
 While {KIE_SERVER} hosts multiple kjar containers, One {KOGITO} instance hosts one domain service. Hence, you would create {KOGITO} project per kjar container, which would be microservice style.
 

--- a/kogito-docs/assemblies/assembly-business-optimizer-springboot.adoc
+++ b/kogito-docs/assemblies/assembly-business-optimizer-springboot.adoc
@@ -103,7 +103,7 @@ ifdef::COMMUNITY[]
 == Summary
 
 Congratulations!
-You have just developed a https://spring.io/[Spring] application with https://www.optaplanner.org/[{PLANNER_SHORT}]!
+You have just developed a https://spring.io/[Spring] application with https://kie.apache.org/docs/components/optaplanner/[{PLANNER_SHORT}]!
 
 endif::COMMUNITY[]
 

--- a/kogito-docs/doc-content/apache-kie-kogito/src/main/asciidoc/creating-running/chap-kogito-creating-running.adoc
+++ b/kogito-docs/doc-content/apache-kie-kogito/src/main/asciidoc/creating-running/chap-kogito-creating-running.adoc
@@ -26,7 +26,7 @@ When you use {PRODUCT}, you are building a cloud-native application as a set of 
 
 If you need long-lived processes, you can persist the runtime state externally in a data grid such as Infinispan or the provided Data Index service. Each {PRODUCT} service also produces events that can be consumed by other services. For example, if you use Apache Kafka, events can be aggregated and indexed in a data index service, offering advanced query capabilities through GraphQL.
 
-{PRODUCT} includes components that are based on well-known business automation KIE projects, specifically https://drools.org[Drools], https://jbpm.org[jBPM], and https://optaplanner.org[OptaPlanner], to offer dependable open source solutions for business rules, business processes, and constraint solving.
+{PRODUCT} includes components that are based on well-known business automation KIE projects, specifically https://kie.apache.org/docs/components/drools/[Drools], https://kie.apache.org/docs/components/jbpm/[jBPM], and https://kie.apache.org/docs/components/optaplanner/[OptaPlanner], to offer dependable open source solutions for business rules, business processes, and constraint solving.
 
 === Cloud-first priority
 
@@ -3191,7 +3191,7 @@ A project build option that provides a fast feedback loop from code changes to a
 * https://quarkus.io/guides/maven-tooling[_Quarkus - Building applications with Maven_]
 
 DRL rule::
-A definition of a business rule in Drools Rule Language (DRL) format. DRL is a notation established by the https://www.drools.org/[Drools] open source business automation project for defining and describing business rules.
+A definition of a business rule in Drools Rule Language (DRL) format. DRL is a notation established by the https://kie.apache.org/docs/components/drools/[Drools] open source business automation project for defining and describing business rules.
 +
 [role="_additional-resources"]
 .Additional resources

--- a/kogito-docs/doc-content/apache-kie-kogito/src/main/asciidoc/drl/chap-kogito-using-drl-rules.adoc
+++ b/kogito-docs/doc-content/apache-kie-kogito/src/main/asciidoc/drl/chap-kogito-using-drl-rules.adoc
@@ -12,7 +12,7 @@ include::{asciidoc-dir}/dmn/chap-kogito-using-dmn-models.adoc[tags=ref-decision-
 == Drools Rule Language (DRL)
 
 [role="_abstract"]
-Drools Rule Language (DRL) is a notation established by the https://www.drools.org/[Drools] open source business automation project for defining and describing business rules. You define DRL rules in `.drl` text files. A DRL file can contain one or more rules that define at a minimum the rule conditions (`when`) and actions (`then`).
+Drools Rule Language (DRL) is a notation established by the https://kie.apache.org/docs/components/drools/[Drools] open source business automation project for defining and describing business rules. You define DRL rules in `.drl` text files. A DRL file can contain one or more rules that define at a minimum the rule conditions (`when`) and actions (`then`).
 
 DRL files consist of the following components:
 

--- a/kogito-docs/doc-content/apache-kie-kogito/src/main/asciidoc/index.adoc
+++ b/kogito-docs/doc-content/apache-kie-kogito/src/main/asciidoc/index.adoc
@@ -19,7 +19,7 @@
 include::{artifact-dir}/document-attributes.adoc[]
 
 = {PRODUCT} Documentation
-The {PRODUCT} Community <https://kie.apache.org/community/>
+The {PRODUCT} Community <https://kie.apache.org/docs/community/>
 :context: kogito-docs
 :doctype: book
 :title-logo-image: image:logos/kogitoLogo.png[align="center"]

--- a/optaplanner-docs/src/modules/ROOT/pages/.index.adoc
+++ b/optaplanner-docs/src/modules/ROOT/pages/.index.adoc
@@ -18,7 +18,7 @@ under the License.
 ////
 
 = OptaPlanner User Guide
-The OptaPlanner Team <https://www.optaplanner.org/community/team.html>
+The OptaPlanner Team <https://kie.apache.org/docs/community/>
 :doctype: book
 :imagesdir: .
 :title-logo-image: image:shared/optaPlannerLogo.png[align="center"]

--- a/optaplanner-docs/src/modules/ROOT/pages/drools-score-calculation/drools-score-calculation.adoc
+++ b/optaplanner-docs/src/modules/ROOT/pages/drools-score-calculation/drools-score-calculation.adoc
@@ -220,7 +220,7 @@ and it must match with the xref:score-calculation/score-calculation.adoc#constra
 [NOTE]
 ====
 To learn more about the Drools rule language (DRL),
-consult https://drools.org/learn/documentation.html[the Drools documentation].
+consult https://kie.apache.org/docs/documentation/[the Drools documentation].
 ====
 
 The score weight of some constraints depends on the constraint match.

--- a/optaplanner-docs/src/modules/ROOT/pages/planner-introduction/planner-introduction.adoc
+++ b/optaplanner-docs/src/modules/ROOT/pages/planner-introduction/planner-introduction.adoc
@@ -31,7 +31,7 @@ under the License.
 Every organization faces planning problems: providing products or services with a limited set of _constrained_ resources (employees, assets, time and money). OptaPlanner optimizes such planning to do more business with less resources.
 This is known as _Constraint Satisfaction Programming_ (which is part of the _Operations Research_ discipline).
 
-https://www.optaplanner.org[OptaPlanner] is a lightweight, embeddable constraint satisfaction engine which optimizes planning problems. It solves use cases such as:
+https://kie.apache.org/docs/components/optaplanner/[OptaPlanner] is a lightweight, embeddable constraint satisfaction engine which optimizes planning problems. It solves use cases such as:
 
 * **Employee shift rostering**: timetabling nurses, repairmen, ...
 * **Agenda scheduling**: scheduling meetings, appointments, maintenance jobs, advertisements, ...
@@ -186,21 +186,18 @@ https://twitter.com/OptaPlanner[twitter] (including https://twitter.com/Geoffrey
 and https://www.facebook.com/OptaPlanner[facebook]. +
 *If you're happy with OptaPlanner, make us happy by posting a tweet or blog article about it.*
 
-Public questions are welcome on https://www.optaplanner.org/community/getHelp.html[here].
-Bugs and feature requests are welcome in https://issues.redhat.com/browse/PLANNER[our issue tracker].
+Public questions are welcome on https://kie.apache.org/docs/community/[here].
+Bugs and feature requests are welcome in https://github.com/apache/incubator-kie-issues/issues[our issue tracker].
 Pull requests are very welcome on GitHub and get priority treatment! By open sourcing your improvements, you'll benefit from our peer review and from our improvements made on top of your improvements.
-
-Red Hat sponsors OptaPlanner development by employing the core team.
-For enterprise support and consulting, take a look at https://www.optaplanner.org/product/services.html[these services].
 
 
 [[relationshipWithKie]]
 === Relationship with KIE
 
-OptaPlanner is part of the http://www.kiegroup.org[KIE group of projects].
+OptaPlanner is part of the https://kie.apache.org/[Apache KIE project].
 It releases regularly (typically every 3 weeks) together.
 
-See xref:optimization-algorithms/optimization-algorithms.adoc#architectureOverview[the architecture overview] to learn more about the optional integration with http://www.drools.org/[Drools].
+See xref:optimization-algorithms/optimization-algorithms.adoc#architectureOverview[the architecture overview] to learn more about the optional integration with https://kie.apache.org/docs/components/drools/[Drools].
 
 [[downloadAndRunTheExamples]]
 == Download and run the examples
@@ -211,7 +208,7 @@ See xref:optimization-algorithms/optimization-algorithms.adoc#architectureOvervi
 
 To try it now:
 
-. Download a release zip of OptaPlanner from https://www.optaplanner.org[the OptaPlanner website] and unzip it.
+. Download a release zip of OptaPlanner from https://kie.apache.org/docs/components/optaplanner/[the OptaPlanner website] and unzip it.
 . Open the directory [path]_examples_ and run the script.
 +
 Linux or Mac:

--- a/optaplanner-docs/src/modules/ROOT/pages/quickstart/hello-world/hello-world-quickstart.adoc
+++ b/optaplanner-docs/src/modules/ROOT/pages/quickstart/hello-world/hello-world-quickstart.adoc
@@ -26,7 +26,7 @@ under the License.
 include::../../_attributes.adoc[]
 
 This guide walks you through the process of creating a simple Java application
-with https://www.optaplanner.org/[OptaPlanner]'s constraint solving Artificial Intelligence (AI).
+with https://kie.apache.org/docs/components/optaplanner/[OptaPlanner]'s constraint solving Artificial Intelligence (AI).
 
 == What you will build
 
@@ -705,7 +705,7 @@ After building the project, you can find an archive with a runnable application 
 == Summary
 
 Congratulations!
-You have just developed a Java application with https://www.optaplanner.org/[OptaPlanner]!
+You have just developed a Java application with https://kie.apache.org/docs/components/optaplanner/[OptaPlanner]!
 
 If you ran into any issues,
 take a look at {hello-world-java-quickstart-url}[the quickstart source code].

--- a/optaplanner-docs/src/modules/ROOT/pages/quickstart/quarkus/quarkus-quickstart.adoc
+++ b/optaplanner-docs/src/modules/ROOT/pages/quickstart/quarkus/quarkus-quickstart.adoc
@@ -30,7 +30,7 @@ include::../../_attributes.adoc[]
 // Keep this also in sync with spring-boot-quickstart.adoc where applicable
 
 This guide walks you through the process of creating a https://quarkus.io/[Quarkus] application
-with https://www.optaplanner.org/[OptaPlanner]'s constraint solving Artificial Intelligence (AI).
+with https://kie.apache.org/docs/components/optaplanner/[OptaPlanner]'s constraint solving Artificial Intelligence (AI).
 
 == What you will build
 
@@ -589,7 +589,7 @@ Use `trace` logging to show every _step_ and every _move_ per step.
 == Summary
 
 Congratulations!
-You have just developed a Quarkus application with https://www.optaplanner.org/[OptaPlanner]!
+You have just developed a Quarkus application with https://kie.apache.org/docs/components/optaplanner/[OptaPlanner]!
 
 == Further improvements: Database and UI integration
 

--- a/optaplanner-docs/src/modules/ROOT/pages/quickstart/spring-boot/spring-boot-quickstart.adoc
+++ b/optaplanner-docs/src/modules/ROOT/pages/quickstart/spring-boot/spring-boot-quickstart.adoc
@@ -29,7 +29,7 @@ include::../../_attributes.adoc[]
 // Keep this in sync with quarkus-quickstart.adoc where applicable
 
 This guide walks you through the process of creating a Spring Boot application
-with https://www.optaplanner.org/[OptaPlanner]'s constraint solving Artificial Intelligence (AI).
+with https://kie.apache.org/docs/components/optaplanner/[OptaPlanner]'s constraint solving Artificial Intelligence (AI).
 
 == What you will build
 
@@ -541,7 +541,7 @@ Use `trace` logging to show every _step_ and every _move_ per step.
 == Summary
 
 Congratulations!
-You have just developed a Spring application with https://www.optaplanner.org/[OptaPlanner]!
+You have just developed a Spring application with https://kie.apache.org/docs/components/optaplanner/[OptaPlanner]!
 
 == Further improvements: Database and UI integration
 

--- a/optaplanner-docs/src/modules/ROOT/pages/release-notes/release-notes-8.adoc
+++ b/optaplanner-docs/src/modules/ROOT/pages/release-notes/release-notes-8.adoc
@@ -355,7 +355,7 @@ Use cases with tri and quad streams may experience order of magnitude speedups.
 Use cases with xref:constraint-streams/constraint-streams.adoc#constraintStreamsGroupingAndCollectors[grouping]
 are likely to experience some speedups too, albeit comparatively smaller.
 
-Kudos to the link:https://drools.org/[Drools] team for helping make this possible!
+Kudos to the link:https://kie.apache.org/docs/components/drools/[Drools] team for helping make this possible!
 
 ==== Constraint Streams `groupBy()` overloads for multiple collectors
 

--- a/optaplanner-docs/src/modules/ROOT/pages/use-cases-and-examples/vaccination-scheduling/vaccination-scheduling.adoc
+++ b/optaplanner-docs/src/modules/ROOT/pages/use-cases-and-examples/vaccination-scheduling/vaccination-scheduling.adoc
@@ -31,7 +31,7 @@ Use the {optaplanner} vaccination appointment scheduler quick start to develop a
 
 * An IDE, such as IntelliJ IDEA, VSCode, Eclipse, or NetBeans is available.
 
-* You have created a Quakus OptaPlanner project as described in https://www.optaplanner.org/docs/optaplanner/latest/quickstart/quickstart.html#quarkusJavaQuickStart[Quarkus Java quick start].
+* You have created a Quakus OptaPlanner project as described in xref:quickstart/quarkus/quarkus-quickstart.adoc#quarkusJavaQuickStart[Quarkus Java quick start].
 
 
 [[vaccinationSchedulerApproach]]


### PR DESCRIPTION
Replaced links

* `https://drools.org` to `https://kie.apache.org/docs/components/drools/`
* `https://jbpm.org` to `https://kie.apache.org/docs/components/jbpm/`
* `https://optaplanner.org` to `https://kie.apache.org/docs/components/optaplanner/`
* `https://kogito.kie.org/` to `https://kie.apache.org/docs/components/kogito/`

Some links are still remaining, which I cannot think of a good replacement for. But most of them are replaced. 