### PR TITLE
[incubator-kie-issues-2170] Incorrect content in the "started by" sec…

### DIFF
--- a/drools-docs/src/modules/ROOT/pages/rule-engine/_cep-temporal-operators.adoc
+++ b/drools-docs/src/modules/ROOT/pages/rule-engine/_cep-temporal-operators.adoc
@@ -459,7 +459,7 @@ The `started by` operator supports one optional parameter that sets the maximum 
 
 [source]
 ----
-$eventA : EventA( this starts[5s] $eventB)
+$eventA : EventA( this startedby[5s] $eventB)
 ----
 
 This pattern matches if these conditions are met:


### PR DESCRIPTION
- Closes https://github.com/apache/incubator-kie-issues/issues/2170

<img width="480" height="300" alt="startedby03" src="https://github.com/user-attachments/assets/1bd4af3c-df9b-47d3-a626-d5c6cd2486d0" />
