### PR TITLE
[incubator-kie-drools-6534] Fix document "acc" in example

### DIFF
--- a/drools-docs/src/modules/ROOT/pages/language-reference-traditional/_drl-rules-WHEN-elements-ref.adoc
+++ b/drools-docs/src/modules/ROOT/pages/language-reference-traditional/_drl-rules-WHEN-elements-ref.adoc
@@ -412,7 +412,7 @@ end
 ----
 --
 
-`accumulate`::
+`accumulate` (`acc`)::
 Use this to iterate over a collection of objects, execute custom actions for each of the elements, and return one or more result objects (if the constraints evaluate to `true`). This element is a more flexible and powerful form of the `collect` condition element. You can use predefined functions in your `accumulate` conditions or implement custom functions as needed. You can also use the abbreviation `acc` for `accumulate` in rule conditions.
 +
 --

--- a/drools-docs/src/modules/ROOT/pages/language-reference/_drl-rules.adoc
+++ b/drools-docs/src/modules/ROOT/pages/language-reference/_drl-rules.adoc
@@ -2124,7 +2124,7 @@ NOTE: The format `forall( p1 p2 p3 ...)` is equivalent to `not( p1 and not( and 
 --
 
 [id=accumulate]
-`accumulate`::
+`accumulate` (`acc`)::
 Use this to iterate over a collection of objects, execute custom actions for each of the elements, and return one or more result objects (if the constraints evaluate to `true`). You can use predefined functions in your `accumulate` conditions or implement custom functions as needed. You can also use the abbreviation `acc` for `accumulate` in rule conditions.
 +
 --

--- a/drools-docs/src/modules/ROOT/pages/rule-engine/_execution-control-con.adoc
+++ b/drools-docs/src/modules/ROOT/pages/rule-engine/_execution-control-con.adoc
@@ -82,14 +82,14 @@ For example, the following sample DRL rules belong to specified agenda groups an
 rule "Increase balance for credits"
   agenda-group "calculation"
 when
-  ap : AccountPeriod()
-  acc : Account( $accountNo : accountNo )
+  $ap : AccountPeriod()
+  $acc : Account( $accountNo : accountNo )
   CashFlow( type == CREDIT,
             accountNo == $accountNo,
-            date >= ap.start && <= ap.end,
+            date >= $ap.start && <= $ap.end,
             $amount : amount )
 then
-  acc.balance  += $amount;
+  $acc.balance  += $amount;
 end
 ----
 
@@ -98,11 +98,11 @@ end
 rule "Print balance for AccountPeriod"
   agenda-group "report"
 when
-  ap : AccountPeriod()
-  acc : Account()
+  $ap : AccountPeriod()
+  $acc : Account()
 then
-  System.out.println( acc.accountNo +
-                      " : " + acc.balance );
+  System.out.println( $acc.accountNo +
+                      " : " + $acc.balance );
 end
 ----
 
@@ -137,11 +137,11 @@ For example, the following sample DRL rules belong to the specified internalMatc
 rule "Print balance for AccountPeriod1"
   activation-group "report"
 when
-  ap : AccountPeriod1()
-  acc : Account()
+  $ap : AccountPeriod1()
+  $acc : Account()
 then
-  System.out.println( acc.accountNo +
-                      " : " + acc.balance );
+  System.out.println( $acc.accountNo +
+                      " : " + $acc.balance );
 end
 ----
 
@@ -150,11 +150,11 @@ end
 rule "Print balance for AccountPeriod2"
   activation-group "report"
 when
-  ap : AccountPeriod2()
-  acc : Account()
+  $ap : AccountPeriod2()
+  $acc : Account()
 then
-  System.out.println( acc.accountNo +
-                      " : " + acc.balance );
+  System.out.println( $acc.accountNo +
+                      " : " + $acc.balance );
 end
 ----
 

--- a/kogito-docs/doc-content/apache-kie-kogito/src/main/asciidoc/decision-engine/chap-kogito-decision-engine.adoc
+++ b/kogito-docs/doc-content/apache-kie-kogito/src/main/asciidoc/decision-engine/chap-kogito-decision-engine.adoc
@@ -858,14 +858,14 @@ For example, the following sample DRL rules belong to specified agenda groups an
 rule "Increase balance for credits"
   agenda-group "calculation"
 when
-  ap : AccountPeriod()
-  acc : Account( $accountNo : accountNo )
+  $ap : AccountPeriod()
+  $acc : Account( $accountNo : accountNo )
   CashFlow( type == CREDIT,
             accountNo == $accountNo,
-            date >= ap.start && <= ap.end,
+            date >= $ap.start && <= $ap.end,
             $amount : amount )
 then
-  acc.balance  += $amount;
+  $acc.balance  += $amount;
 end
 ----
 
@@ -874,11 +874,11 @@ end
 rule "Print balance for AccountPeriod"
   agenda-group "report"
 when
-  ap : AccountPeriod()
-  acc : Account()
+  $ap : AccountPeriod()
+  $acc : Account()
 then
-  System.out.println( acc.accountNo +
-                      " : " + acc.balance );
+  System.out.println( $acc.accountNo +
+                      " : " + $acc.balance );
 end
 ----
 
@@ -914,11 +914,11 @@ For example, the following sample DRL rules belong to the specified activation g
 rule "Print balance for AccountPeriod1"
 activation-group "report"
   when
-    ap : AccountPeriod1()
-    acc : Account()
+    $ap : AccountPeriod1()
+    $acc : Account()
   then
-    System.out.println( acc.accountNo +
-                      " : " + acc.balance );
+    System.out.println( $acc.accountNo +
+                      " : " + $acc.balance );
 end
 ----
 
@@ -927,11 +927,11 @@ end
 rule "Print balance for AccountPeriod2"
 activation-group "report"
   when
-    ap : AccountPeriod2()
-    acc : Account()
+    $ap : AccountPeriod2()
+    $acc : Account()
   then
-    System.out.println( acc.accountNo +
-                      " : " + acc.balance );
+    System.out.println( $acc.accountNo +
+                      " : " + $acc.balance );
 end
 ----
 

--- a/kogito-docs/doc-content/apache-kie-kogito/src/main/asciidoc/drl/chap-kogito-using-drl-rules.adoc
+++ b/kogito-docs/doc-content/apache-kie-kogito/src/main/asciidoc/drl/chap-kogito-using-drl-rules.adoc
@@ -2282,7 +2282,7 @@ NOTE: The format `forall( p1 p2 p3 ...)` is equivalent to `not( p1 and not( and 
 
 --
 
-`accumulate`::
+`accumulate` (`acc`)::
 Use this to iterate over a collection of objects, execute custom actions for each of the elements, and return one or more result objects (if the constraints evaluate to `true`). You can use predefined functions in your `accumulate` conditions or implement custom functions as needed. You can also use the abbreviation `acc` for `accumulate` in rule conditions.
 +
 --


### PR DESCRIPTION
- Fixes https://github.com/apache/incubator-kie-drools/issues/6534
    - Fixed examples which use `acc` (= keyword) to `$acc`.
    - Emphasize the abbreviation `acc` a bit more in docs
