### PR TITLE
[incubator-kie-drools-6549] Drop unused drools soft keywords

### DIFF
--- a/drools-docs/src/modules/ROOT/pages/release-notes/_release-notes-10.2.adoc
+++ b/drools-docs/src/modules/ROOT/pages/release-notes/_release-notes-10.2.adoc
@@ -1,0 +1,32 @@
+////
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+////
+
+== 10.2.0 release notes
+
+=== Drop unused DRL soft keywords
+
+The following unused DRL soft keywords have been removed:
+
+* `refract`
+* `direct`
+* `template`
+
+These keywords had no effect. Starting with this version, DRL files that contain any of these keywords will result in build errors, so they must be removed from the DRLs.
+
+Note that the `template` keyword here is not related to `drools-templates`.

--- a/drools-docs/src/modules/ROOT/pages/release-notes/index.adoc
+++ b/drools-docs/src/modules/ROOT/pages/release-notes/index.adoc
@@ -30,6 +30,8 @@ This chapter contains the release notes for the {PRODUCT} 10-series.
 
 For the release notes of the _previous releases_, you can refer to the {PRODUCT} documentation of link:https://docs.drools.org/8.44.0.Final/drools-docs/drools/release-notes/index.html[version 8].
 
+include::_release-notes-10.2.adoc[leveloffset=0]
+
 include::_release-notes-10.1.adoc[leveloffset=0]
 
 include::_release-notes-10.0.adoc[leveloffset=0]


### PR DESCRIPTION
- Relates to https://github.com/apache/incubator-kie-drools/issues/6549

