### PR TITLE
[incubator-kie-drools-6635] Add agenda-group deprecation for DRL10 in…

### DIFF
--- a/drools-docs/src/modules/ROOT/pages/language-reference/_language-level.adoc
+++ b/drools-docs/src/modules/ROOT/pages/language-reference/_language-level.adoc
@@ -87,6 +87,24 @@ The custom operator's implementation Java code wouldn't need to be changed.
    Person(age > 10 && age < 20)
 ----
 
+* Drop `agenda-group` to be replaced by `ruleflow-group`
+
+.DRL6
+[source]
+----
+   agenda-group "my-group"
+----
+
+.DRL10 (also valid in DRL6)
+[source]
+----
+   ruleflow-group "my-group"
+----
+
+`agenda-group` behaves the same as `ruleflow-group`, so this attribute has been consolidated into `ruleflow-group` in DRL10.
+
+This deprecation applies only to the DRL syntax; the Java APIs for `agenda-group` remain supported.
+
 * Drop double ampersand as infix and
 
 .DRL6

--- a/drools-docs/src/modules/ROOT/pages/release-notes/_release-notes-10.1.adoc
+++ b/drools-docs/src/modules/ROOT/pages/release-notes/_release-notes-10.1.adoc
@@ -26,6 +26,7 @@ DRL10 introduces the following changes mainly to reduce ambiguity:
 
 * Require a prefix '##' to custom operators
 * Drop half constraint syntax
+* Drop `agenda-group` to be replaced by `ruleflow-group`
 * Drop double ampersand as infix and
 * Drop double pipe as infix or
 * Drop annotation inside LHS pattern


### PR DESCRIPTION
… docs and release notes

Closes https://github.com/apache/incubator-kie-drools/issues/6635

<!-- Please provide a short description of what this PR does -->
**Description:**
Add agenda-group deprecation for DRL10 in docs and release notes

- [x] Pull Request title is properly formatted: `Issue-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting main: `[0.9.x] Issue-XYZ Subject`
- [x] The nav.adoc file has a link to this guide in the proper category
- [x] The index.adoc file has a card to this guide in the proper category, with a meaningful description

This is a PR for main. Currently there is no `10.2.x`, it will be branched from main.