### PR TITLE
[incubator-kie-drools-6637] Docs: remove externaliseCanonicalModelLam…

### DIFF
--- a/drools-docs/src/modules/ROOT/pages/rule-engine/_performance-tuning-rule-engine-ref.adoc
+++ b/drools-docs/src/modules/ROOT/pages/rule-engine/_performance-tuning-rule-engine-ref.adoc
@@ -61,19 +61,6 @@ Configure `LambdaIntrospector` cache size for an executable model build::
 You can configure the size of `LambdaIntrospector.methodFingerprintsMap` cache, which is used in an executable model build. The default size of the cache is `32`. When you configure smaller value for the cache size, it reduces memory usage. For example, you can configure system property `drools.lambda.introspector.cache.size` to `0` for minimum memory usage. Note that smaller cache size also slows down the build performance.
 
 
-Use lambda externalization for executable model::
-Enable lambda externalization to optimize the memory consumption during runtime. It rewrites lambdas that are generated and used in the executable model. This enables you to reuse the same lambda multiple times with all the patterns and the same constraint. When the rete or phreak is instantiated, the executable model becomes garbage collectible.
-+
---
-To enable lambda externalization for the executable model, include the following property:
-
-[source]
-----
--Ddrools.externaliseCanonicalModelLambda=true
-----
---
-
-
 Configure alpha node range index threshold::
 Alpha node range index is used to evaluate the rule constraint. You can configure the threshold of the alpha node range index using the `drools.alphaNodeRangeIndexThreshold` system property. The default value of the threshold is `9`, indicating that the alpha node range index is enabled when a precedent node contains more than nine alpha nodes with inequality constraints. For example, when you have nine rules similar to `Person(age > 10)`, `Person(age > 20)`, ..., `Person(age > 90)`, then you can have similar nine alpha nodes.
 +


### PR DESCRIPTION
…bda from "Performance tuning considerations with the Drools rule engine"

<!-- Please don't forget your Issue link -->
Closes https://github.com/apache/incubator-kie-drools/issues/6637