### PR TITLE
kie-issues#2299: use pass:[] for ## cases.

### DIFF
--- a/drools-docs/src/modules/ROOT/pages/language-reference-traditional/_custom-operators-section.adoc
+++ b/drools-docs/src/modules/ROOT/pages/language-reference-traditional/_custom-operators-section.adoc
@@ -178,5 +178,5 @@ Custom operators cannot use brackets in their names. In other words, you cannot 
 
 [NOTE]
 ====
-In Language Level DRL10, custom operators must be prefixed with `##` to avoid ambiguity with other syntax. For example, the operator `supersetOf` should be used as `##supersetOf` in DRL10.
+In Language Level DRL10, custom operators must be prefixed with `pass:[##]` to avoid ambiguity with other syntax. For example, the operator `supersetOf` should be used as `pass:[##supersetOf]` in DRL10.
 ====

--- a/drools-docs/src/modules/ROOT/pages/release-notes/_release-notes-10.1.adoc
+++ b/drools-docs/src/modules/ROOT/pages/release-notes/_release-notes-10.1.adoc
@@ -24,7 +24,7 @@ New language level DRL10 has been added. DRL10 is handled by the new parser base
 
 DRL10 introduces the following changes mainly to reduce ambiguity:
 
-* Require a prefix '##' to custom operators
+* Require a prefix `pass:[##]` to custom operators
 * Drop half constraint syntax
 * Drop `agenda-group` to be replaced by `ruleflow-group`
 * Drop double ampersand as infix and


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-kie-issues/issues/2299

PR changes `##` to `pass:[##]`
